### PR TITLE
Fixes unregister method of BasicXDocReportDispatcher.

### DIFF
--- a/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/dispatcher/BasicXDocReportDispatcher.java
+++ b/document/fr.opensagres.xdocreport.document/src/main/java/fr/opensagres/xdocreport/document/dispatcher/BasicXDocReportDispatcher.java
@@ -27,6 +27,7 @@ package fr.opensagres.xdocreport.document.dispatcher;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class BasicXDocReportDispatcher<T extends IXDocReportController>
     extends AbstractXDocReportDispatcher<T>
@@ -50,18 +51,18 @@ public class BasicXDocReportDispatcher<T extends IXDocReportController>
         controllersMap.put( reportId, controller );
     }
 
-    public void unregister( T controller )
+    public void unregister( final T controller )
     {
-        controllersMap.remove( controller );
+        controllersMap.entrySet().removeIf(new Predicate<Map.Entry<String, T>>() {
+            public boolean test(Map.Entry<String, T> t) {
+                return t.getValue() == controller;
+            }
+        });
     }
 
     public void unregister( String reportId )
     {
-        T controller = controllersMap.get( reportId );
-        if ( controller != null )
-        {
-            unregister( controller );
-        }
+        controllersMap.remove( reportId );
     }
 
     public Collection<T> getControllers()


### PR DESCRIPTION
According to Javadoc, `Map.remove(K key)`:

> Removes the mapping for a key from this map if it is present (optional operation).   More formally, if this map contains a mapping from key `k` to value `v` such that `(key==null ?  k==null : key.equals(k))`, that mapping is removed.  (The map can contain at most one such mapping.)
